### PR TITLE
Fix array merging

### DIFF
--- a/extend.and.merge.1.0.js
+++ b/extend.and.merge.1.0.js
@@ -54,7 +54,7 @@
 						if(jQuery.isArray(target[name])){
 							jQuery.merge(target[name],copy);
 						}else{
-							target[name]=copy;
+							target[name]= Array.prototype.slice.call(copy);
 						}
 					}else
 					// Never move original objects, clone them


### PR DESCRIPTION
Never assign a copy array, but clone it. Otherwise copy array gets extended, which is not something expected
